### PR TITLE
polymorphic role+user+resource access control

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           extensions: zip, sqlite3
           coverage: none
 

--- a/README.md
+++ b/README.md
@@ -4,28 +4,36 @@
 [![Test](https://github.com/codinglabsau/laravel-roles/actions/workflows/run-tests.yml/badge.svg)](https://github.com/codinglabsau/laravel-roles/actions/workflows/run-tests.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/codinglabsau/laravel-roles.svg?style=flat-square)](https://packagist.org/packages/codinglabsau/laravel-roles)
 
-A simple, flexible roles implementation for Laravel v6-v9. 
+A simple, flexible roles implementation for Laravel v6-v9.
 
 ## Installation
+
 ### Install with composer
+
 ```bash
 $ composer require codinglabsau/laravel-roles
 ```
 
 ### Publish migrations and migrate
+
 ```bash
 php artisan vendor:publish --tag="roles-migrations"
 php artisan migrate
 ```
 
 ## Configuration
-If you need to override the default `Role` model, you can do that by publishing the config and setting the `models.role` option.
+
+If you need to override the default `Role` model, you can do that by publishing the config and setting the `models.role`
+option.
+
 ```
 php artisan vendor:publish --tag="roles-config"
 ```
 
 ## Usage
+
 ### Add the trait
+
 Add the `HasRoles` trait to your user model:
 
 ```php
@@ -40,17 +48,21 @@ class User extends Authenticatable
 ```
 
 ### Create roles
+
 ```php
 $role = \Codinglabs\Roles\Role::create(['name' => 'manager']);
 ```
 
 ### Get roles
+
 ```php
 $managerRole = \Codinglabs\Roles\Role::whereName('manager')->first();
 ```
 
 ### Associate roles
+
 Under the hood we are using Eloquent many-to-many relationships.
+
 ```php
 use Codinglabs\Roles\Role;
 
@@ -75,7 +87,9 @@ $user->roles()->syncWithoutDetaching([
 ```
 
 ### Protect routes with middleware
-In `App\Http\Kernel`, register the middeware: 
+
+In `App\Http\Kernel`, register the middeware:
+
 ```php
 protected $routeMiddleware = [
     // ...
@@ -84,12 +98,14 @@ protected $routeMiddleware = [
 ```
 
 And then call the middleware in your routes, seperating multiple roles with a pipe:
+
 ```php
 Route::middleware('role:employee')->...
 Route::middleware('role:manager|admin')->...
 ```
 
 Or with a gate:
+
 ```php
 class UserController extends Controller
 {
@@ -101,6 +117,7 @@ class UserController extends Controller
 ```
 
 Or in the constructor of a controller:
+
 ```php
 class ManagerDashboardController extends Controller
 {
@@ -112,6 +129,7 @@ class ManagerDashboardController extends Controller
 ```
 
 Or with a policy:
+
 ```php
 class StorePostController extends Controller
 {
@@ -133,7 +151,9 @@ class StorePostRequest extends FormRequest
 All of the examples above with produce a 403 Unauthorized response.
 
 ### Check roles on a user
+
 Call hasRole on the user model:
+
 ```php
 // check a single role
 $user->hasRole('foo');
@@ -146,19 +166,40 @@ $user->roles;
 ```
 
 ### Role resource access control
-Sometimes you may want to not only check whether the user has a role, but whether they should have access to a particular resource. This is where role resource access control comes in.
 
-You can grant a user access to a resource as follows: 
+Sometimes you may want to not only check whether the user has a role, but whether they should have access to a
+particular resource. This is where role resource access control comes in.
+
+You can grant a user access to a resource as follows:
+
 ```php
-$user->grantRoleAccessToResource...
+$role = Role::whereName('manager')->first();
+
+$user->resources()->create([
+    'role_id' => $role->id,
+    'resource_type' => Post::class,
+    'resource_id' => 1,
+]);
 ```
 
 And check if the user can access a resource:
+
 ```php
-$user->canAccessResource($post);
+$user->hasResourceRole($resource, $role);
+```
+
+Or from the resource side:  
+```php
+class Post extends Model  
+{
+    use HasResourceRoles;
+}
+
+$post->hasUserWithRole($user, $role);
 ```
 
 The easiest way to implement this is with Laravel Policies.
+
 ```php
 class PostPolicy
 {
@@ -170,6 +211,7 @@ class PostPolicy
 ```
 
 ### Conditionally showing content with the blade directive
+
 ```html
 @role('admin')
 <div>Super secret admin stuff goes here...</div>
@@ -177,6 +219,7 @@ class PostPolicy
 ```
 
 ### Sharing roles with UI (Inertiajs example)
+
 ```php
 // AppServiceProvider.php
 Inertia::share([
@@ -190,36 +233,46 @@ Inertia::share([
     }
 ]);
 ```
+
 ```javascript
 // app.js
 Vue.mixin({
   methods: {
-    hasRole: function(role) {
+    hasRole: function (role) {
       return this.$page.auth.user.roles.includes(role)
     }
   }
 })
 ```
+
 ```html
 <!-- SomeComponent.vue -->
 <div v-if="hasRole('manager')">I am a manager</div>
 ```
 
 ## Upgrading from v1 to v2
-Please see [upgrading from v1 to v2](UPGRADING.md) for details and instructions to avoid any issues after upgrading to v2.
+
+Please see [upgrading from v1 to v2](UPGRADING.md) for details and instructions to avoid any issues after upgrading to
+v2.
 
 ## Contributing
+
 Please see [contributing.md](contributing.md) for details and a todolist.
 
 ## Security
+
 If you discover any security related issues, create an issue on GitHub.
 
 ## Credits
+
 - [Steve Thomas](https://github.com/stevethomas)
 - [All Contributors](../../contributors)
 
 ## License
+
 MIT. Please see the [license file](LICENSE.md) for more information.
 
 ## About Coding Labs
-Coding Labs is a web app development agency based on the Gold Coast, Australia. See our open source projects [on our website](https://codinglabs.com.au/open-source).
+
+Coding Labs is a web app development agency based on the Gold Coast, Australia. See our open source
+projects [on our website](https://codinglabs.com.au/open-source).

--- a/README.md
+++ b/README.md
@@ -111,7 +111,26 @@ class ManagerDashboardController extends Controller
 }
 ```
 
-If the middleware check fails, a 403 response will be returned.
+Or with a policy:
+```php
+class StorePostController extends Controller
+{
+    public function __invoke(StorePostRequest $request)
+    {
+        // save post
+    }
+}
+
+class StorePostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return auth()->user()->hasRole('admin');
+    }
+}
+```
+
+All of the examples above with produce a 403 Unauthorized response.
 
 ### Check roles on a user
 Call hasRole on the user model:
@@ -124,6 +143,30 @@ $user->hasRole(['bar', 'baz']);
 
 // get all roles
 $user->roles;
+```
+
+### Role resource access control
+Sometimes you may want to not only check whether the user has a role, but whether they should have access to a particular resource. This is where role resource access control comes in.
+
+You can grant a user access to a resource as follows: 
+```php
+$user->grantRoleAccessToResource...
+```
+
+And check if the user can access a resource:
+```php
+$user->canAccessResource($post);
+```
+
+The easiest way to implement this is with Laravel Policies.
+```php
+class PostPolicy
+{
+    public function update(User $user, Post $post): bool
+    {
+        return $post->user->is($user) || $user->canAccessResource($post);
+    }
+}
 ```
 
 ### Conditionally showing content with the blade directive

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
     "homepage": "https://github.com/codinglabsau/laravel-roles",
     "keywords": ["Laravel", "Roles"],
     "require": {
-        "php" : "^7.3|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0"
+        "php" : "^8.0",
+        "illuminate/support": "^8.0|^9.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0|^9.0",
-        "orchestra/testbench": "^4.0|^5.0|^6.0"
+        "orchestra/testbench": "^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/config/roles.php
+++ b/config/roles.php
@@ -12,6 +12,7 @@ return [
     */
 
     'models' => [
-        'role' => \Codinglabs\Roles\Role::class
+        'role' => \Codinglabs\Roles\Role::class,
+        'role_acls' => \Codinglabs\Roles\RoleAcls::class,
     ]
 ];

--- a/database/migrations/2022_10_13_041303_create_role_acls_table.php
+++ b/database/migrations/2022_10_13_041303_create_role_acls_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateRoleAclsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('role_acls', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('role_id')->unsigned()->nullable();
+            $table->integer('user_id')->unsigned();
+            $table->string('resource_type');
+            $table->string('resource_id');
+            $table->timestamps();
+
+            $table->index(['role_id', 'user_id']);
+            $table->index(['resource_type', 'resource_id']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('role_acls');
+    }
+}

--- a/database/migrations/2022_10_13_041303_create_role_acls_table.php
+++ b/database/migrations/2022_10_13_041303_create_role_acls_table.php
@@ -12,12 +12,12 @@ class CreateRoleAclsTable extends Migration
             $table->increments('id');
             $table->integer('role_id')->unsigned()->nullable();
             $table->integer('user_id')->unsigned();
-            $table->string('resource_type');
-            $table->string('resource_id');
+            $table->string('resourceable_type');
+            $table->string('resourceable_id');
             $table->timestamps();
 
             $table->index(['role_id', 'user_id']);
-            $table->index(['resource_type', 'resource_id']);
+            $table->index(['resourceable_type', 'resourceable_id']);
         });
     }
 

--- a/src/CheckRole.php
+++ b/src/CheckRole.php
@@ -7,14 +7,6 @@ use Illuminate\Support\Str;
 
 class CheckRole
 {
-    /**
-     * Handle an incoming request.
-     *
-     * @param \Illuminate\Http\Request $request
-     * @param \Closure $next
-     * @param string $roles
-     * @return mixed
-     */
     public function handle($request, Closure $next, $roles)
     {
         abort_unless($request->user(), 401, 'Unauthorized');

--- a/src/HasRoles.php
+++ b/src/HasRoles.php
@@ -3,7 +3,7 @@
 namespace Codinglabs\Roles;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 trait HasRoles
@@ -14,9 +14,9 @@ trait HasRoles
             ->withTimestamps();
     }
 
-    public function resource(): MorphOne
+    public function resources(): MorphMany
     {
-        return $this->morphOne(config('roles.models.role_acls'), 'resource');
+        return $this->morphMany(config('roles.models.role_acls'), 'resourceable');
     }
 
     public function hasRole(string|array|Role $role): bool

--- a/src/HasRoles.php
+++ b/src/HasRoles.php
@@ -2,7 +2,6 @@
 
 namespace Codinglabs\Roles;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
@@ -14,7 +13,7 @@ trait HasRoles
             ->withTimestamps();
     }
 
-    public function resources(): MorphMany
+    public function resourceables(): MorphMany
     {
         return $this->morphMany(config('roles.models.role_acls'), 'resourceable');
     }
@@ -34,14 +33,5 @@ trait HasRoles
         return $this->roles
             ->whereIn('name', $roleNames)
             ->isNotEmpty();
-    }
-
-    public function canAccessResource(Model $model): bool
-    {
-        return $this->accessible()
-            ->where([
-                'accessible_type' => get_class($model),
-                'accessible_id' => $model->id,
-            ])->exists();
     }
 }

--- a/src/RoleAcls.php
+++ b/src/RoleAcls.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Codinglabs\Roles;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class RoleAcls extends Model
+{
+    protected $guarded = [];
+
+    public function resourceable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/tests/RoleTest.php
+++ b/tests/RoleTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Codinglabs\Roles\Tests;
+
+class RoleTest extends TestCase
+{
+    /** @test */
+    public function has_role_false_when_new_user()
+    {
+        $this->assertFalse((new User())->hasRole('admin'));
+    }
+
+    /** @test */
+    public function has_role_false_when_role_not_found()
+    {
+        $this->assertFalse($this->user->hasRole('admin'));
+    }
+
+    /** @test */
+    public function has_role_true_when_role_exists()
+    {
+        $this->user->roles()->create(['name' => 'admin']);
+        $this->user->roles()->attach('admin');
+
+        $this->assertTrue($this->user->hasRole('admin'));
+    }
+
+    /** @test */
+    public function can_create_acls()
+    {
+        $this->user->resource()->create([
+            'role_id' => 2,
+            'user_id' => $this->user->id,
+            'resource_type' => User::class,
+            'resource_id' => 1,
+        ]);
+
+        $this->assertDatabaseHas('role_acls', [
+            'role_id' => 2,
+            'user_id' => $this->user->id,
+            'resource_type' => User::class,
+            'resource_id' => 1,
+        ]);
+    }
+}

--- a/tests/RoleTest.php
+++ b/tests/RoleTest.php
@@ -28,18 +28,18 @@ class RoleTest extends TestCase
     /** @test */
     public function can_create_acls()
     {
-        $this->user->resource()->create([
+        $this->user->resourceables()->create([
             'role_id' => 2,
             'user_id' => $this->user->id,
-            'resource_type' => User::class,
-            'resource_id' => 1,
+            'resourceable_type' => User::class,
+            'resourceable_id' => 1,
         ]);
 
         $this->assertDatabaseHas('role_acls', [
             'role_id' => 2,
             'user_id' => $this->user->id,
-            'resource_type' => User::class,
-            'resource_id' => 1,
+            'resourceable_type' => User::class,
+            'resourceable_id' => 1,
         ]);
     }
 }


### PR DESCRIPTION
This PR is an experimental, incomplete attempt to add role-level resource access control.

For many situations, we either:
- have a user role that allows access to any resource (ie. support agent can access all support tickets)
- identify the resource owner via a `user_id` column on the database, and use that for authorisation

There is a less 3-pronged common scenario, where a resource is shared amongst multiple users, with each user having different levels of access based on a role. Two real-world examples:

- Multiple users can interact with a `Job`, as P1 engineer, P2 engineer or certifier
- Multiple users can manage a `Store`, as an admin, customer service offer, or stock manager

[Jestream](https://jetstream.laravel.com/2.x/features/teams.html) actually deals with this problem area, and might turn out to be a better alternative. What Jetstream seems to lack is the global role capability in this package, but it does have a pretty neat team roles+permissions implementation.

The difference to Jetstream is that this PR effectively assembles a hybrid team around any model in the application; so multiple users can be associated with any resource in the app without needing to separately create a team. 

See the changes to the README to see how the new capabilities would work.

- [ ] decide whether to use `resource` or `model` for the language 